### PR TITLE
Use GITHUB_TOKEN for release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -15,7 +18,7 @@ jobs:
       - name: Run GoReleaser
         uses: docker://goreleaser/goreleaser:v0.118
         env:
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           args: release
         if: success()


### PR DESCRIPTION
This makes use of a GITHUB_TOKEN instead of a custom secret. The token has restricted scope for the current repo[1] and with the only permissions[2] for the go releaser action.

[1]: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
[2]: https://goreleaser.com/ci/actions/#token-permissions